### PR TITLE
Skip equip prevention only for creative player.

### DIFF
--- a/src/main/java/valorless/havenbags/prevention/EquipPrevention.java
+++ b/src/main/java/valorless/havenbags/prevention/EquipPrevention.java
@@ -18,7 +18,7 @@ public class EquipPrevention implements Listener {
 
 	@EventHandler
     public void onInventoryClick(InventoryClickEvent event) {
-		if (event.getWhoClicked().getGameMode() != GameMode.SURVIVAL) {
+		if (event.getWhoClicked().getGameMode() == GameMode.CREATIVE) {
             return;
         }
         Log.Debug(Main.plugin, "[DI-194] " + "[EquipPrevention] " + event.getWhoClicked().getOpenInventory().getTopInventory().getType());


### PR DESCRIPTION
On my testing for #12 I found that player on adventure mode could equip bags

So this PR make fix and make more obvious the, probably, intended goal of this guard statement (also prevent for spectator player, but should already be prevented as should not be able to move item)